### PR TITLE
Add simple file upload endpoint

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -3,7 +3,10 @@ package com.example.demo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootApplication
 @RestController
@@ -16,5 +19,10 @@ public class DemoApplication {
     @GetMapping("/")
     public String home() {
         return "Hello, Spring Boot!";
+    }
+
+    @PostMapping("/upload")
+    public String upload(@RequestParam("file") MultipartFile file) {
+        return "Uploaded: " + file.getOriginalFilename();
     }
 }

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -2,11 +2,36 @@ package com.example.demo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class DemoApplicationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @Test
     void contextLoads() {
+    }
+
+    @Test
+    void uploadEndpointAcceptsFile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.txt",
+                "text/plain",
+                "hello".getBytes()
+        );
+
+        mockMvc.perform(multipart("/upload").file(file))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("test.txt")));
     }
 }


### PR DESCRIPTION
## Summary
- add /upload endpoint for accepting multipart file uploads
- test file upload behavior with MockMvc

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issue)*

------
https://chatgpt.com/codex/tasks/task_e_684104bea21c83218db3b06ee900468f